### PR TITLE
fix(core): add DNS propegation timeout

### DIFF
--- a/terraform/wings/cloud-init/wing.yml
+++ b/terraform/wings/cloud-init/wing.yml
@@ -37,8 +37,10 @@ runcmd:
   - chown root:wings /usr/local/bin/wings
   - chmod u+x /usr/local/bin/wings
   - chmod g+x /usr/local/bin/wings
+  # Waiting for DNS to propagate
+  - IP=$(curl -s http://ifconfig.me); while [ "$(dig +short ${domain})" != "$IP" ]; do echo "Waiting for DNS to propagate"; sleep 5; done
+  - echo "DNS has propagated"  
   # Setting up SSL
-  # TODO: Waiting for DNS to propagate
   - certbot certonly --standalone --agree-tos --no-eff-email --email ${email} -d ${domain}
   # Configuring wings
   - wings configure --panel-url ${pterodactyl_panel_url} --token ${pterodactyl_panel_api_key} --node ${node_id}

--- a/terraform/wings/tf-modules/wing-node/wing-node.tf
+++ b/terraform/wings/tf-modules/wing-node/wing-node.tf
@@ -50,7 +50,7 @@ resource "cloudflare_record" "node_dns_a_record" {
   allow_overwrite = true
   zone_id         = data.cloudflare_zones.domain_name_zone.zones.0.id
   name            = var.dns_a_record
-  value           = hcloud_server.node.ipv4_address
+  content         = hcloud_server.node.ipv4_address
   type            = "A"
   ttl             = "60"
   proxied         = false


### PR DESCRIPTION
This fixes #27 by adding a continuous wait until the DNS record that is needed for SSL is correctly returning the IPv4 of the server.